### PR TITLE
Platforms now have the option to no longer allow the player to jump through them.

### DIFF
--- a/PlatformExperimenting/Platform.cpp
+++ b/PlatformExperimenting/Platform.cpp
@@ -2,8 +2,8 @@
 #include "BoxCollider.h"
 #include "PhysicsManager.h"
 
-Platform::Platform(bool canBeStoodOn, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderSize, Vector2 colliderOffset) :
-	mCanBeStoodOn(canBeStoodOn) {
+Platform::Platform(bool canBeStoodOn, bool canBeJumpedThrough, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderSize, Vector2 colliderOffset) :
+	mCanBeStoodOn(canBeStoodOn), mCanBeJumpedThrough(canBeJumpedThrough) {
 
 	mPlatformTexture = texture;
 	if (mPlatformTexture != nullptr) {
@@ -35,6 +35,10 @@ Platform::~Platform() {
 
 bool Platform::GetCanBeStoodOn() {
 	return mCanBeStoodOn;
+}
+
+bool Platform::GetCanBeJumpedThrough() {
+	return mCanBeJumpedThrough;
 }
 
 Texture* Platform::GetTexture() {

--- a/PlatformExperimenting/Platform.cpp
+++ b/PlatformExperimenting/Platform.cpp
@@ -2,7 +2,7 @@
 #include "BoxCollider.h"
 #include "PhysicsManager.h"
 
-Platform::Platform(bool canBeStoodOn, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 colliderOffset) :
+Platform::Platform(bool canBeStoodOn, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderSize, Vector2 colliderOffset) :
 	mCanBeStoodOn(canBeStoodOn) {
 
 	mPlatformTexture = texture;
@@ -13,7 +13,15 @@ Platform::Platform(bool canBeStoodOn, Vector2 position, GLTexture* texture, Vect
 	}
 
 	Position(position);
-	AddCollider(new BoxCollider(Vector2(mPlatformTexture->ScaledDimensions().x, mPlatformTexture->ScaledDimensions().y)), colliderOffset);
+
+	if (boxColliderSize.x == 0.0f && boxColliderSize.y == 0.0f) {
+		std::cout << "No Collider Size given! Using Texture Dimensions." << std::endl;
+		AddCollider(new BoxCollider(Vector2(mPlatformTexture->ScaledDimensions().x, mPlatformTexture->ScaledDimensions().y)), colliderOffset);
+	}
+	else {
+		std::cout << "Collider Size given! Using it!" << std::endl;
+		AddCollider(new BoxCollider(Vector2(boxColliderSize.x, boxColliderSize.y)), colliderOffset);
+	}
 
 	mId = PhysicsManager::Instance()->RegisterEntity(this, PhysicsManager::CollisionLayers::Platforms);
 	mName = "Platform";

--- a/PlatformExperimenting/Platform.h
+++ b/PlatformExperimenting/Platform.h
@@ -11,7 +11,7 @@ private:
 
 public:
 	Platform(bool canBeStoodOn, Vector2 Position, GLTexture* texture,
-		Vector2 scale = Vector2(1.0f, 1.0f), Vector2 colliderOffset = Vec2_Zero);
+		Vector2 scale = Vector2(1.0f, 1.0f), Vector2 boxColliderSize = Vec2_Zero, Vector2 colliderOffset = Vec2_Zero);
 	~Platform();
 
 	// Inherited from PhysEntity

--- a/PlatformExperimenting/Platform.h
+++ b/PlatformExperimenting/Platform.h
@@ -6,11 +6,12 @@ using namespace SDLFramework;
 class Platform : public PhysEntity {
 private:
 	bool mCanBeStoodOn;
+	bool mCanBeJumpedThrough;
 
 	Texture* mPlatformTexture;
 
 public:
-	Platform(bool canBeStoodOn, Vector2 Position, GLTexture* texture,
+	Platform(bool canBeStoodOn, bool canBeJumpedThrough, Vector2 Position, GLTexture* texture,
 		Vector2 scale = Vector2(1.0f, 1.0f), Vector2 boxColliderSize = Vec2_Zero, Vector2 colliderOffset = Vec2_Zero);
 	~Platform();
 
@@ -18,6 +19,7 @@ public:
 	void Hit(PhysEntity* other) override;
 
 	bool GetCanBeStoodOn();
+	bool GetCanBeJumpedThrough();
 
 	Texture* GetTexture();
 

--- a/PlatformExperimenting/PlatformManager.cpp
+++ b/PlatformExperimenting/PlatformManager.cpp
@@ -47,8 +47,8 @@ namespace SDLFramework {
 		}
 	}
 
-	void PlatformManager::CreateNewPlatform(bool standable, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderSize, Vector2 boxColliderOffset) {
-		Platform* platform = new Platform(standable, position, texture, scale, boxColliderSize, boxColliderOffset);
+	void PlatformManager::CreateNewPlatform(bool standable, bool canJumpThrough, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderSize, Vector2 boxColliderOffset) {
+		Platform* platform = new Platform(standable, canJumpThrough, position, texture, scale, boxColliderSize, boxColliderOffset);
 		AddPlatformToMap(platform);
 	}
 

--- a/PlatformExperimenting/PlatformManager.cpp
+++ b/PlatformExperimenting/PlatformManager.cpp
@@ -47,8 +47,8 @@ namespace SDLFramework {
 		}
 	}
 
-	void PlatformManager::CreateNewPlatform(bool standable, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderOffset) {
-		Platform* platform = new Platform(standable, position, texture, scale, boxColliderOffset);
+	void PlatformManager::CreateNewPlatform(bool standable, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderSize, Vector2 boxColliderOffset) {
+		Platform* platform = new Platform(standable, position, texture, scale, boxColliderSize, boxColliderOffset);
 		AddPlatformToMap(platform);
 	}
 

--- a/PlatformExperimenting/PlatformManager.h
+++ b/PlatformExperimenting/PlatformManager.h
@@ -17,7 +17,7 @@ namespace SDLFramework {
 		static PlatformManager* Instance();
 		static void Release();
 
-		void CreateNewPlatform(bool Standable, Vector2 position, GLTexture* texture, Vector2 scale, Vector2 boxColliderOffset = Vec2_Zero);
+		void CreateNewPlatform(bool Standable, Vector2 position, GLTexture* texture, Vector2 scale = Vec2_One, Vector2 boxColliderSize = Vec2_Zero, Vector2 boxColliderOffset = Vec2_Zero);
 		void AddPlatformToMap(Platform* platformToAdd);
 
 		Platform* GetPlatform(unsigned long ID);

--- a/PlatformExperimenting/PlatformManager.h
+++ b/PlatformExperimenting/PlatformManager.h
@@ -17,7 +17,7 @@ namespace SDLFramework {
 		static PlatformManager* Instance();
 		static void Release();
 
-		void CreateNewPlatform(bool Standable, Vector2 position, GLTexture* texture, Vector2 scale = Vec2_One, Vector2 boxColliderSize = Vec2_Zero, Vector2 boxColliderOffset = Vec2_Zero);
+		void CreateNewPlatform(bool Standable, bool canJumpThrough, Vector2 position, GLTexture* texture, Vector2 scale = Vec2_One, Vector2 boxColliderSize = Vec2_Zero, Vector2 boxColliderOffset = Vec2_Zero);
 		void AddPlatformToMap(Platform* platformToAdd);
 
 		Platform* GetPlatform(unsigned long ID);

--- a/PlatformExperimenting/PlayScreen.cpp
+++ b/PlatformExperimenting/PlayScreen.cpp
@@ -19,9 +19,9 @@ PlayScreen::PlayScreen() {
 
 	mPlatformTexture = new GLTexture("Black.png");
 
-	mPlatforms->CreateNewPlatform(true, Vector2(Graphics::SCREEN_WIDTH * 0.5, Graphics::SCREEN_HEIGHT * 0.7f), mPlatformTexture, Vector2(1.6f, 0.2f));
-	mPlatforms->CreateNewPlatform(true, Vector2(Graphics::SCREEN_WIDTH * 0.3, Graphics::SCREEN_HEIGHT * 0.6f), mPlatformTexture, Vector2(1.6f, 0.2f));
-	mPlatforms->CreateNewPlatform(true, Vector2(Graphics::SCREEN_WIDTH * 0.5, Graphics::SCREEN_HEIGHT * 0.85), mPlatformTexture, Vector2(9.0f, 0.2f));
+	mPlatforms->CreateNewPlatform(true, false, Vector2(Graphics::SCREEN_WIDTH * 0.5, Graphics::SCREEN_HEIGHT * 0.7f), mPlatformTexture, Vector2(1.6f, 0.2f));
+	mPlatforms->CreateNewPlatform(true, true, Vector2(Graphics::SCREEN_WIDTH * 0.3, Graphics::SCREEN_HEIGHT * 0.7f), mPlatformTexture, Vector2(1.6f, 0.2f));
+	mPlatforms->CreateNewPlatform(true, false, Vector2(Graphics::SCREEN_WIDTH * 0.5, Graphics::SCREEN_HEIGHT * 0.85), mPlatformTexture, Vector2(9.0f, 0.2f));
 
 }
 

--- a/PlatformExperimenting/Player.cpp
+++ b/PlatformExperimenting/Player.cpp
@@ -138,10 +138,16 @@ void Player::AddScore(int change) {
 
 void Player::Hit(PhysEntity * other) {
 	if (other->GetName() == mPlatforms->GetPlatform(other->GetId())->GetName()) {
-		if (mPlatforms->GetPlatform(other->GetId())->GetCanBeStoodOn() && Position().y + mPlayerTexture->ScaledDimensions().y >= mPlatforms->GetPlatformPosition(other->GetId()).y) {
-			if (Position().x >= mPlatforms->GetPlatformPosition(other->GetId()).x - mPlatforms->GetPlatform(other->GetId())->GetTexture()->ScaledDimensions().x / 2 &&
-				Position().x <= mPlatforms->GetPlatformPosition(other->GetId()).x + mPlatforms->GetPlatform(other->GetId())->GetTexture()->ScaledDimensions().x / 2) {
+		if (mPlatforms->GetPlatform(other->GetId())->GetCanBeStoodOn() && 
+			Position().y + (mPlayerTexture->ScaledDimensions().y * 0.5) <= mPlatforms->GetPlatformPosition(other->GetId()).y) {
+			if (Position().x > mPlatforms->GetPlatformPosition(other->GetId()).x - mPlatforms->GetPlatform(other->GetId())->GetTexture()->ScaledDimensions().x / 2 &&
+				Position().x < mPlatforms->GetPlatformPosition(other->GetId()).x + mPlatforms->GetPlatform(other->GetId())->GetTexture()->ScaledDimensions().x / 2) {
  				mGrounded = true;
+			}
+		}
+		else if (Position().y - (mPlayerTexture->ScaledDimensions().y * 0.5) >= mPlatforms->GetPlatformPosition(other->GetId()).y) {
+			if (mJumpTime <= 0.5 * mJumpSpeed) {
+				mJumpTime = 0.5 * mJumpSpeed;
 			}
 		}
 		else {

--- a/PlatformExperimenting/Player.cpp
+++ b/PlatformExperimenting/Player.cpp
@@ -145,7 +145,8 @@ void Player::Hit(PhysEntity * other) {
  				mGrounded = true;
 			}
 		}
-		else if (Position().y - (mPlayerTexture->ScaledDimensions().y * 0.5) >= mPlatforms->GetPlatformPosition(other->GetId()).y) {
+		else if (!mPlatforms->GetPlatform(other->GetId())->GetCanBeJumpedThrough() &&
+			Position().y - (mPlayerTexture->ScaledDimensions().y * 0.5) >= mPlatforms->GetPlatformPosition(other->GetId()).y) {
 			if (mJumpTime <= 0.5 * mJumpSpeed) {
 				mJumpTime = 0.5 * mJumpSpeed;
 			}


### PR DESCRIPTION
Added the ability to tell a platform when it is created whether or not the player should be allowed to jump through it. Platforms that prevent this ability act as a ceiling when the player collides with them from underneath.